### PR TITLE
Fixes from the lf-edge/eve repo

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/digitalocean/go-qemu
+module github.com/lf-edge/go-qemu
 
 go 1.18
 

--- a/qmp/socket.go
+++ b/qmp/socket.go
@@ -197,7 +197,15 @@ func (mon *SocketMonitor) listen(r io.Reader, events chan<- Event, stream chan<-
 	}
 
 	if err := scanner.Err(); err != nil {
-		stream <- streamResponse{err: err}
+		// In case stream reader went away we wait for a bit
+		waitTimer := time.NewTimer(3 * time.Second)
+		defer waitTimer.Stop()
+		select {
+		case <-waitTimer.C:
+			// Do nothing
+		case stream <- streamResponse{err: err}:
+			// Done
+		}
 	}
 }
 


### PR DESCRIPTION
This PR switches the go-qemu project clone to the lf-edge and applies two commits taken from the lf-edge/eve repo:

1. Don't stuck the queue processing if there is no events listener.
2. Fixing possible mixed up response with events (QMP protocol).

CC: @eriknordmark 


